### PR TITLE
Update revshellgen.py

### DIFF
--- a/revshellgen.py
+++ b/revshellgen.py
@@ -133,7 +133,7 @@ def select_command():
 
 
 def select_shell():
-    if command != 'windows_powershell' and command != 'unix_bash' and command != 'unix_telnet':
+    if command not in ('windows_powershell', 'unix_bash', 'unix_telnet'):
         print(header.safe_substitute(text='SELECT SHELL'))
         global shell
         shell = shells[(select(shells))]


### PR DESCRIPTION
it’s generally better to use `x not in (…)` instead of `x != … and x != …` and so on because it will then be easier to add more checks in the future